### PR TITLE
Implement multi-asset mock trading account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+/.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Mock Account
+
+A lightweight Python toolkit for simulating a multi-asset, multi-currency brokerage account. It keeps track of cash balances, FIFO-based positions, realized and unrealized PnL and supports pluggable fee models.
+
+## Features
+
+- Multiple assets with independent price streams.
+- Multi-currency cash management with FX conversion to a configurable base currency.
+- FIFO accounting for positions and realized PnL history with FX references.
+- Pluggable fee models (flat or notional) with support for rebates.
+- Snapshot utilities for balance, equity and unrealized PnL.
+- Comprehensive transaction, fee and realized PnL history retrieval.
+
+## Installation
+
+The project is a plain Python package. Add the repository root to your `PYTHONPATH` or install it in editable mode:
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+```python
+from mock_account import MockAccount, FlatFeeModel
+
+account = MockAccount(
+    base_currency="USD",
+    initial_balances={"USD": 10_000.0},
+    fee_models=[FlatFeeModel(amount=1.5, currency="USD")],
+)
+
+account.update_fx_rate("HKD", "USD", rate=0.128, timestamp=1700000000)
+account.update_price("0700.HK", price=300.0, currency="HKD", timestamp=1700000000)
+account.record_trade("0700.HK", quantity=100, price=300.0, currency="HKD", timestamp=1700000000)
+account.update_price("0700.HK", price=320.0, currency="HKD", timestamp=1700003600)
+
+state = account.get_account_state()
+print(state["equity"], state["unrealized_pnl"])
+
+for instrument, position in account.get_positions().items():
+    print(instrument, position)
+```
+
+## Testing
+
+```bash
+pytest
+```

--- a/mock_account/__init__.py
+++ b/mock_account/__init__.py
@@ -1,0 +1,13 @@
+"""Mock trading account with multi-currency, multi-asset support."""
+
+from .account import MockAccount, RealizedPnL
+from .fees import Fee, FeeModel, FlatFeeModel, PerNotionalFeeModel
+
+__all__ = [
+    "MockAccount",
+    "RealizedPnL",
+    "Fee",
+    "FeeModel",
+    "FlatFeeModel",
+    "PerNotionalFeeModel",
+]

--- a/mock_account/account.py
+++ b/mock_account/account.py
@@ -1,0 +1,306 @@
+"""Core account model for the mock trading environment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, MutableMapping, Optional, Tuple
+
+from .fees import Fee, FeeModel, apply_fee_models
+
+
+@dataclass
+class PriceRecord:
+    price: float
+    currency: str
+    timestamp: int
+    metadata: Optional[Dict[str, object]] = None
+
+
+@dataclass
+class FxRate:
+    rate: float
+    timestamp: int
+
+
+@dataclass
+class PositionLot:
+    quantity: float
+    price: float
+    currency: str
+    timestamp: int
+
+
+@dataclass
+class RealizedPnL:
+    instrument: str
+    quantity: float
+    direction: str
+    amount: float
+    currency: str
+    base_amount: float
+    base_currency: str
+    fx_rate: float
+    timestamp: int
+    open_timestamp: int
+
+
+class MockAccount:
+    """Maintain multi-asset, multi-currency trading balances using FIFO.
+
+    Parameters
+    ----------
+    base_currency:
+        All reported balances are expressed in this currency. FX rates must be
+        supplied so that amounts can be converted into ``base_currency``.
+    initial_balances:
+        Optional mapping from currency to opening cash balance. Currencies that
+        are not present start at zero.
+    fee_models:
+        Optional iterable of :class:`FeeModel` instances used to calculate trade
+        fees. Multiple models can be supplied and will be evaluated in order.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_currency: str,
+        initial_balances: Optional[MutableMapping[str, float]] = None,
+        fee_models: Optional[Iterable[FeeModel]] = None,
+    ) -> None:
+        self.base_currency = base_currency
+        self.cash_balances: Dict[str, float] = {
+            currency: float(amount) for currency, amount in (initial_balances or {}).items()
+        }
+        self.positions: Dict[str, List[PositionLot]] = {}
+        self.prices: Dict[str, PriceRecord] = {}
+        self.fx_rates: Dict[Tuple[str, str], FxRate] = {}
+        self.trade_history: List[Dict[str, object]] = []
+        self.fee_history: List[Fee] = []
+        self.realized_pnl_history: List[RealizedPnL] = []
+        self.fee_models: List[FeeModel] = list(fee_models or [])
+
+    # ------------------------------------------------------------------
+    # Data ingestion utilities
+    # ------------------------------------------------------------------
+    def update_price(
+        self,
+        instrument: str,
+        *,
+        price: float,
+        currency: str,
+        timestamp: int,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> None:
+        """Update the latest price for ``instrument``."""
+
+        self.prices[instrument] = PriceRecord(
+            price=float(price),
+            currency=currency,
+            timestamp=int(timestamp),
+            metadata=metadata,
+        )
+
+    def update_fx_rate(
+        self,
+        from_currency: str,
+        to_currency: str,
+        *,
+        rate: float,
+        timestamp: int,
+    ) -> None:
+        """Register an FX rate that converts ``from_currency`` into ``to_currency``."""
+
+        fx = FxRate(rate=float(rate), timestamp=int(timestamp))
+        self.fx_rates[(from_currency, to_currency)] = fx
+        if rate != 0:
+            self.fx_rates[(to_currency, from_currency)] = FxRate(rate=1.0 / float(rate), timestamp=int(timestamp))
+
+    def record_trade(
+        self,
+        instrument: str,
+        *,
+        quantity: float,
+        price: float,
+        currency: str,
+        timestamp: int,
+        multiplier: float = 1.0,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> None:
+        """Record a trade for ``instrument`` and update cash, positions and fees."""
+
+        trade = {
+            "instrument": instrument,
+            "quantity": float(quantity),
+            "price": float(price),
+            "currency": currency,
+            "timestamp": int(timestamp),
+            "multiplier": float(multiplier),
+        }
+        if metadata is not None:
+            trade["metadata"] = metadata
+
+        if trade["quantity"] == 0:
+            raise ValueError("quantity must be non-zero")
+
+        self._apply_cash_flow(currency=currency, amount=-trade["quantity"] * trade["price"] * trade["multiplier"])
+        fees = apply_fee_models(self.fee_models, trade)
+        for fee in fees:
+            self._apply_cash_flow(currency=fee.currency, amount=-fee.amount)
+        self.fee_history.extend(fees)
+        self.trade_history.append(trade)
+
+        realized = self._update_positions(trade)
+        self.realized_pnl_history.extend(realized)
+
+    # ------------------------------------------------------------------
+    # Reporting utilities
+    # ------------------------------------------------------------------
+    def get_account_state(self) -> Dict[str, float]:
+        """Return balance, equity and unrealized PnL expressed in base currency."""
+
+        cash_base = self._cash_in_base()
+        positions_value, unrealized = self._positions_valuation()
+        equity = cash_base + positions_value
+        return {
+            "balance": cash_base,
+            "equity": equity,
+            "unrealized_pnl": unrealized,
+        }
+
+    def get_trade_history(self) -> List[Dict[str, object]]:
+        return list(self.trade_history)
+
+    def get_fee_history(self) -> List[Fee]:
+        return list(self.fee_history)
+
+    def get_realized_pnl_history(self) -> List[RealizedPnL]:
+        return list(self.realized_pnl_history)
+
+    def get_cash_balances(self) -> Dict[str, float]:
+        """Return a copy of current cash balances by currency."""
+
+        return dict(self.cash_balances)
+
+    def get_positions(self) -> Dict[str, Dict[str, float]]:
+        """Return the current open positions keyed by instrument."""
+
+        summary: Dict[str, Dict[str, float]] = {}
+        for instrument, lots in self.positions.items():
+            if not lots:
+                continue
+            net_quantity = sum(lot.quantity for lot in lots)
+            if abs(net_quantity) < 1e-12:
+                continue
+            cost = sum(lot.price * lot.quantity for lot in lots)
+            currency = lots[0].currency
+            average_price = cost / net_quantity
+            summary[instrument] = {
+                "net_quantity": net_quantity,
+                "average_price": average_price,
+                "currency": currency,
+            }
+        return summary
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _apply_cash_flow(self, *, currency: str, amount: float) -> None:
+        self.cash_balances[currency] = self.cash_balances.get(currency, 0.0) + float(amount)
+
+    def _cash_in_base(self) -> float:
+        total = 0.0
+        for currency, amount in self.cash_balances.items():
+            total += self._convert(amount, currency, self.base_currency)
+        return total
+
+    def _positions_valuation(self) -> Tuple[float, float]:
+        market_value = 0.0
+        unrealized = 0.0
+        for instrument, lots in self.positions.items():
+            if not lots:
+                continue
+            price = self.prices.get(instrument)
+            if price is None:
+                raise ValueError(f"Missing price for {instrument}")
+            for lot in lots:
+                if lot.currency != price.currency:
+                    raise ValueError(
+                        f"Currency mismatch for {instrument}: lot {lot.currency} vs price {price.currency}"
+                    )
+            net_qty = sum(lot.quantity for lot in lots)
+            market_value += self._convert(price.price * net_qty, price.currency, self.base_currency)
+            for lot in lots:
+                lot_pnl = (price.price - lot.price) * lot.quantity
+                unrealized += self._convert(lot_pnl, lot.currency, self.base_currency)
+        return market_value, unrealized
+
+    def _convert(self, amount: float, from_currency: str, to_currency: str) -> float:
+        if from_currency == to_currency:
+            return float(amount)
+        key = (from_currency, to_currency)
+        if key not in self.fx_rates:
+            raise ValueError(f"Missing FX rate for {from_currency}->{to_currency}")
+        rate = self.fx_rates[key]
+        return float(amount) * rate.rate
+
+    def _update_positions(self, trade: Dict[str, object]) -> List[RealizedPnL]:
+        instrument = str(trade["instrument"])
+        quantity = float(trade["quantity"]) * float(trade["multiplier"])
+        price = float(trade["price"])
+        currency = str(trade["currency"])
+        timestamp = int(trade["timestamp"])
+
+        lots = self.positions.setdefault(instrument, [])
+        realized: List[RealizedPnL] = []
+
+        qty_to_process = quantity
+        idx = 0
+        while idx < len(lots) and qty_to_process != 0:
+            lot = lots[idx]
+            if (lot.quantity > 0) == (qty_to_process > 0):
+                break
+            match_qty = min(abs(qty_to_process), abs(lot.quantity))
+            direction = 1.0 if lot.quantity > 0 else -1.0
+            pnl_amount = (price - lot.price) * match_qty * direction
+            fx_rate = self._fx_rate_for(currency)
+            realized.append(
+                RealizedPnL(
+                    instrument=instrument,
+                    quantity=match_qty,
+                    direction="long" if direction > 0 else "short",
+                    amount=pnl_amount,
+                    currency=currency,
+                    base_amount=pnl_amount * fx_rate,
+                    base_currency=self.base_currency,
+                    fx_rate=fx_rate,
+                    timestamp=timestamp,
+                    open_timestamp=lot.timestamp,
+                )
+            )
+
+            lot.quantity -= direction * match_qty
+            qty_to_process += direction * match_qty
+            if abs(lot.quantity) < 1e-12:
+                lots.pop(idx)
+            else:
+                idx += 1
+
+        if abs(qty_to_process) > 1e-12:
+            lots.append(
+                PositionLot(
+                    quantity=qty_to_process,
+                    price=price,
+                    currency=currency,
+                    timestamp=timestamp,
+                )
+            )
+
+        return realized
+
+    def _fx_rate_for(self, currency: str) -> float:
+        if currency == self.base_currency:
+            return 1.0
+        key = (currency, self.base_currency)
+        if key not in self.fx_rates:
+            raise ValueError(f"Missing FX rate for {currency}->{self.base_currency}")
+        return self.fx_rates[key].rate

--- a/mock_account/fees.py
+++ b/mock_account/fees.py
@@ -1,0 +1,121 @@
+"""Fee model abstractions used by the mock trading account."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class Fee:
+    """Represents a fee charged on a trade.
+
+    Attributes
+    ----------
+    name:
+        Descriptive name for the fee (e.g. "commission", "rebate").
+    amount:
+        The monetary amount of the fee expressed in ``currency``. Fees that
+        decrease cash balances should therefore use a positive ``amount`` while
+        rebates should provide a negative amount.
+    currency:
+        Currency code for the fee amount.
+    timestamp:
+        Epoch timestamp when the fee is incurred.
+    metadata:
+        Optional dictionary for model specific details such as tier
+        information.
+    """
+
+    name: str
+    amount: float
+    currency: str
+    timestamp: int
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+
+class FeeModel(ABC):
+    """Base class for all fee models.
+
+    Fee models receive the trade dictionary supplied to
+    :meth:`mock_account.account.MockAccount.record_trade` and return the fees
+    that should be charged for the trade. Custom models can subclass
+    :class:`FeeModel` and implement :meth:`calculate`.
+    """
+
+    @abstractmethod
+    def calculate(self, trade: Dict[str, object]) -> Sequence[Fee]:
+        """Return the fees that should be charged for ``trade``."""
+
+
+class FlatFeeModel(FeeModel):
+    """Charges a constant fee for every trade."""
+
+    def __init__(self, amount: float, currency: str, name: str = "flat_fee") -> None:
+        self.amount = float(amount)
+        self.currency = currency
+        self.name = name
+
+    def calculate(self, trade: Dict[str, object]) -> Sequence[Fee]:
+        return [
+            Fee(
+                name=self.name,
+                amount=self.amount,
+                currency=self.currency,
+                timestamp=int(trade["timestamp"]),
+            )
+        ]
+
+
+class PerNotionalFeeModel(FeeModel):
+    """Charges a fee proportional to trade notional.
+
+    Parameters
+    ----------
+    rate:
+        Fee rate expressed as a proportion of trade notional (e.g. ``0.0005``
+        for 5 bps).
+    minimum:
+        Optional minimum fee amount. Defaults to ``0``.
+    currency:
+        Currency in which the fee is charged. When ``None`` the trade currency
+        is used.
+    name:
+        Descriptive name for the fee.
+    """
+
+    def __init__(
+        self,
+        rate: float,
+        *,
+        minimum: float = 0.0,
+        currency: str | None = None,
+        name: str = "notional_fee",
+    ) -> None:
+        self.rate = float(rate)
+        self.minimum = float(minimum)
+        self.currency = currency
+        self.name = name
+
+    def calculate(self, trade: Dict[str, object]) -> Sequence[Fee]:
+        notional = abs(float(trade["price"]) * float(trade["quantity"]) * float(trade.get("multiplier", 1.0)))
+        amount = max(notional * self.rate, self.minimum)
+        currency = self.currency or str(trade["currency"])
+        return [
+            Fee(
+                name=self.name,
+                amount=amount,
+                currency=currency,
+                timestamp=int(trade["timestamp"]),
+            )
+        ]
+
+
+def apply_fee_models(fee_models: Iterable[FeeModel], trade: Dict[str, object]) -> List[Fee]:
+    """Return the combined fees for ``trade`` from all ``fee_models``."""
+
+    fees: List[Fee] = []
+    for model in fee_models:
+        fees.extend(model.calculate(trade))
+    return fees

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mock-account"
+version = "0.1.0"
+description = "Multi-asset, multi-currency mock brokerage account"
+authors = [{name = "Mock Account"}]
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://example.com/mock-account"

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,118 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from mock_account import FlatFeeModel, MockAccount
+
+
+def test_basic_long_position():
+    account = MockAccount(base_currency="USD")
+    account.update_price("AAPL", price=100.0, currency="USD", timestamp=1)
+
+    account.record_trade(
+        "AAPL",
+        quantity=10,
+        price=100.0,
+        currency="USD",
+        timestamp=1,
+    )
+
+    account.update_price("AAPL", price=110.0, currency="USD", timestamp=2)
+
+    state = account.get_account_state()
+    assert state["balance"] == pytest.approx(-1000.0)
+    assert state["unrealized_pnl"] == pytest.approx(100.0)
+    assert state["equity"] == pytest.approx(100.0)
+
+    positions = account.get_positions()
+    assert positions["AAPL"]["net_quantity"] == pytest.approx(10.0)
+
+
+def test_fifo_and_realized_pnl():
+    account = MockAccount(base_currency="USD")
+    account.update_price("AAPL", price=100.0, currency="USD", timestamp=1)
+    account.record_trade("AAPL", quantity=5, price=100.0, currency="USD", timestamp=1)
+    account.record_trade("AAPL", quantity=5, price=105.0, currency="USD", timestamp=2)
+
+    account.update_price("AAPL", price=120.0, currency="USD", timestamp=3)
+    account.record_trade("AAPL", quantity=-6, price=120.0, currency="USD", timestamp=3)
+
+    realized = account.get_realized_pnl_history()
+    assert len(realized) == 2
+    assert realized[0].quantity == pytest.approx(5.0)
+    assert realized[0].amount == pytest.approx(100.0)
+    assert realized[0].direction == "long"
+    assert realized[0].open_timestamp == 1
+    assert realized[1].quantity == pytest.approx(1.0)
+    assert realized[1].amount == pytest.approx(15.0)
+    assert realized[1].open_timestamp == 2
+
+    positions = account.get_positions()
+    assert positions["AAPL"]["net_quantity"] == pytest.approx(4.0)
+    assert positions["AAPL"]["average_price"] == pytest.approx(105.0)
+
+
+def test_fx_and_short_position():
+    account = MockAccount(base_currency="USD")
+    account.update_fx_rate("HKD", "USD", rate=0.128, timestamp=1)
+    account.update_price("0700.HK", price=300.0, currency="HKD", timestamp=1)
+
+    account.record_trade("0700.HK", quantity=100, price=300.0, currency="HKD", timestamp=1)
+    account.update_price("0700.HK", price=320.0, currency="HKD", timestamp=2)
+
+    state = account.get_account_state()
+    assert state["balance"] == pytest.approx(-30000.0 * 0.128)
+    assert state["unrealized_pnl"] == pytest.approx(2000.0 * 0.128)
+    assert state["equity"] == pytest.approx((-30000.0 + 32000.0) * 0.128)
+
+    # Close the position to realize PnL and ensure FX conversion works.
+    account.record_trade("0700.HK", quantity=-100, price=325.0, currency="HKD", timestamp=3)
+    realized = account.get_realized_pnl_history()[-1]
+    assert realized.amount == pytest.approx((325.0 - 300.0) * 100)
+    assert realized.base_amount == pytest.approx((325.0 - 300.0) * 100 * 0.128)
+    assert realized.fx_rate == pytest.approx(0.128)
+
+
+def test_fee_application():
+    account = MockAccount(base_currency="USD", fee_models=[FlatFeeModel(amount=2.0, currency="USD")])
+    account.update_price("MSFT", price=250.0, currency="USD", timestamp=1)
+    account.record_trade("MSFT", quantity=1, price=250.0, currency="USD", timestamp=1)
+
+    fees = account.get_fee_history()
+    assert len(fees) == 1
+    assert fees[0].amount == pytest.approx(2.0)
+    assert account.get_cash_balances()["USD"] == pytest.approx(-252.0)
+
+
+def test_short_position_realized_direction():
+    account = MockAccount(base_currency="USD")
+    account.update_price("ES", price=4000.0, currency="USD", timestamp=1)
+
+    account.record_trade(
+        "ES",
+        quantity=-2,
+        price=4000.0,
+        currency="USD",
+        timestamp=1,
+        multiplier=50,
+    )
+
+    account.update_price("ES", price=3900.0, currency="USD", timestamp=2)
+    state = account.get_account_state()
+    assert state["unrealized_pnl"] == pytest.approx(10000.0)
+    assert state["equity"] == pytest.approx(10000.0)
+
+    account.record_trade(
+        "ES",
+        quantity=2,
+        price=3900.0,
+        currency="USD",
+        timestamp=3,
+        multiplier=50,
+    )
+    realized = account.get_realized_pnl_history()[-1]
+    assert realized.direction == "short"
+    assert realized.amount == pytest.approx(10000.0)


### PR DESCRIPTION
## Summary
- add a mock_account package with FIFO accounting, FX conversion, and fee model support
- expose fee helpers and add README plus packaging metadata for installation
- create pytest coverage for long, short, FX, and fee scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e484c8c1908328ab48af13a3cfa3a0